### PR TITLE
Add caching to /image endpoint

### DIFF
--- a/lime/root/root.py
+++ b/lime/root/root.py
@@ -8,6 +8,7 @@ from flask.ext.login import LoginManager
 from flask.ext.login import login_required, login_user, logout_user, current_user
 from itsdangerous import URLSafeSerializer, BadSignature
 from jinja2 import TemplateNotFound
+from flask_headers import headers
 from .forms import *
 
 from flask import current_app as app
@@ -50,6 +51,7 @@ def post_index():
 
 
 @mod.route('/image/<image_name>')
+@headers({'Cache-Control':'public, max-age=2675309'})
 def image(image_name):
     return retrieve_image(image_name, Host.by_current_user().bucketname)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 DateTime==4.0.1
 Flask==0.9
+Flask-Headers==1.0
 Flask-Login==0.2.11
 Flask-Mail==0.9.0
 Flask-Principal==0.4.0


### PR DESCRIPTION
This fixes #109 by adding a max-age to images requested at the
/image endpoint.