### PR TITLE
Anchor forwarding

### DIFF
--- a/lime/root/root.py
+++ b/lime/root/root.py
@@ -39,6 +39,7 @@ def index():
 def post_index():
     form = LoginForm()
     ref = request.values.get('next', None)
+    anchor = request.values.get('anchor', None)
     if form.validate_on_submit():
         # login and validate the user...
         user = User.objects.get(id=form.user.id)
@@ -46,7 +47,7 @@ def post_index():
         flash("Logged in successfully.")
         if user.admin :
             return redirect(url_for("admin.index"))
-        return redirect(ref or url_for("root.index"))
+        return redirect(ref or url_for("root.index", _anchor=anchor))
     return render_template("login.html", form=form, ref=ref)
 
 

--- a/lime/root/root.py
+++ b/lime/root/root.py
@@ -45,8 +45,6 @@ def post_index():
         user = User.objects.get(id=form.user.id)
         login_user(user)
         flash("Logged in successfully.")
-        if user.admin :
-            return redirect(url_for("admin.index"))
         return redirect(ref or url_for("root.index", _anchor=anchor))
     return render_template("login.html", form=form, ref=ref)
 

--- a/lime/root/views/fancyform.html
+++ b/lime/root/views/fancyform.html
@@ -11,6 +11,7 @@
 <script type='text/javascript'>
   $(document).ready(function() {
     LIME.flash();
+    $('#login #anchor').val((location.href.split("#")[1] || ""));
   });
 </script>
 

--- a/lime/root/views/login.html
+++ b/lime/root/views/login.html
@@ -1,10 +1,11 @@
 {% extends "fancyform.html" %}
 {% block form %}
-  <form action="{{ url_for('root.index') }}" method=post>
+  <form id='login' action="{{ url_for('root.index') }}" method=post>
     {{ render(form) }}
     {% if ref %}
         <input type="hidden" name="next" value="{{ ref }}"/>
     {% endif %}
+    <input type="hidden" id="anchor" name="anchor" value=""/>
   </form>
   <div id="forgot_password">
     <a href="{{ url_for("root.forgot_password") }}">Forgot your password?</a>


### PR DESCRIPTION
This feature affects a user who is not logged in to click a link which points to a vertex such as
`lime.wiota.co/#category/343fdsf908dsd5f6s45df`
This feature passes the anchor text through so the user can be redirected to the original link.