### PR TITLE
Opengraph vertex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nosetests.xml
 
 # vi
 *.swp
+.cache

--- a/lime/__init__.py
+++ b/lime/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from flask_sslify import SSLify
 from flask import Flask, request, render_template, flash
 from urlparse import urlparse
@@ -98,8 +99,10 @@ def load_user(userid):
 
     return AnonymousUser()
 
-if not app.debug:
-    @app.errorhandler(Exception)
-    def catch_all(exception):
+@app.errorhandler(Exception)
+def catch_all(exception):
+    if not (app.debug or app.testing):
         tb = traceback.format_exc()
         LimeExceptionEmail(exception, tb).send()
+    else:
+        raise exception, None, sys.exc_info()[2]

--- a/requirements/_default.txt
+++ b/requirements/_default.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.4.1
 blinker==1.3
 boto==2.31.1
 cssselect==0.9.1
@@ -17,6 +18,7 @@ Jinja2==2.6
 lxml==3.3.5
 mongoengine==0.10.0
 newrelic==2.18.1.15
+opengraph==0.5
 passlib==1.6.2
 premailer==2.5.1
 pyactiveresource==1.0.1
@@ -27,5 +29,6 @@ six==1.9.0
 stripe==1.18.0
 translitcodec==0.3
 Werkzeug==0.8.3
+wheel==0.24.0
 WTForms==1.0.5
 zope.interface==4.1.1

--- a/requirements/_dev.txt
+++ b/requirements/_dev.txt
@@ -1,4 +1,5 @@
 -r _default.txt
-mongomock==3.0.0
-py==1.4.30
-pytest==2.7.2
+mongomock
+py
+pytest
+mock


### PR DESCRIPTION
This parses the any `OpenGraphURL` field on a vertex being saved, fetches the OpenGraph data from the URL, applies it to fields in the Custom Vertex Schema with a corresponding `og` tag.

Also, tests.
